### PR TITLE
feat: add tenant resolver middleware

### DIFF
--- a/middlewares/tenantResolver.js
+++ b/middlewares/tenantResolver.js
@@ -1,0 +1,25 @@
+const tenantService = require('../services/tenantService');
+
+/**
+ * Middleware que resolve o tenant a partir da URL ou header.
+ * - URL: /tenant/:tenantId/...
+ * - Header: X-Tenant-ID
+ */
+module.exports = async function tenantResolver(req, res, next) {
+  try {
+    const tenantId = req.params.tenantId || req.header('x-tenant-id');
+    if (!tenantId) {
+      return res.status(401).json({ error: 'tenant_id_required' });
+    }
+    const tenantConfig = await tenantService.getTenantConfig(tenantId);
+    if (!tenantConfig) {
+      return res.status(404).json({ error: 'tenant_not_found' });
+    }
+    req.tenantId = tenantId;
+    req.tenantConfig = tenantConfig;
+    return next();
+  } catch (err) {
+    console.error('[tenantResolver] Erro:', err.message);
+    return res.status(500).json({ error: 'internal_error' });
+  }
+};

--- a/services/tenantService.js
+++ b/services/tenantService.js
@@ -1,0 +1,31 @@
+const { supabase } = require('./supabaseClient');
+
+/**
+ * Busca as configurações do tenant pelo ID.
+ * @param {string} tenantId
+ * @returns {Promise<Object|null>} Configuração do tenant ou null se não encontrado
+ */
+async function getTenantConfig(tenantId) {
+  if (!tenantId) return null;
+  if (!supabase) {
+    console.warn('[tenantService] Supabase não configurado.');
+    return null;
+  }
+  try {
+    const { data, error } = await supabase
+      .from('tenants')
+      .select('*')
+      .eq('id', tenantId)
+      .single();
+    if (error) {
+      console.warn(`[tenantService] Erro ao buscar tenant ${tenantId}:`, error.message);
+      return null;
+    }
+    return data;
+  } catch (err) {
+    console.error('[tenantService] Falha inesperada:', err.message);
+    return null;
+  }
+}
+
+module.exports = { getTenantConfig };


### PR DESCRIPTION
## Summary
- add tenantService to lookup tenant configuration
- introduce tenantResolver middleware extracting tenantId from URL or header

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ab77446e9c83209831b51641bc22b1