### PR TITLE
Add tenant-aware webhook route with validation middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ whatsapp-chatbot/
 1. Crie uma conta no [Z-API](https://z-api.io)
 2. Crie uma instância do WhatsApp
 3. Obtenha sua API Key e Instance ID
-4. Configure o webhook para: `https://seu-dominio.com/webhook`
+4. Configure o webhook para: `https://seu-dominio.com/tenant/{tenantId}/webhook`
 
 ### GestãoDS Setup
 1. Configure sua conta no GestãoDS
@@ -113,7 +113,7 @@ GET /listagem/{token}?data_inicial=04/08/2025&data_final=03/09/2025
 
 ## 📡 API Endpoints
 
-### POST /webhook
+### POST /tenant/:tenantId/webhook
 Recebe mensagens do Z-API
 
 **Body:**
@@ -157,7 +157,7 @@ Recebe mensagens do Z-API
 
 ## 🔄 Fluxo de Funcionamento
 
-1. **Recebimento**: Z-API envia mensagem para `/webhook`
+1. **Recebimento**: Z-API envia mensagem para `/tenant/:tenantId/webhook`
 2. **Processamento**: `messageController` processa a mensagem
 3. **GestãoDS**: Criação/atualização de leads
 4. **Resposta**: Envio da resposta via Z-API

--- a/env.example
+++ b/env.example
@@ -1,6 +1,7 @@
 # Configurações do Servidor
 NODE_ENV=development
 PORT=3000
+TENANT_IDS=
 
 # Z-API (WhatsApp)
 ZAPI_INSTANCE_ID=

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const { flowController } = require('./services/flowController');
 const zapiService = require('./services/zapiService');
 const { supabase } = require('./services/supabaseClient');
 const LOG_MESSAGES = process.env.LOG_MESSAGES || 'key';
+const tenantMiddleware = require('./middlewares/tenantMiddleware');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -46,7 +47,7 @@ const painelRouter = require('./routes/painel');
 app.use('/api/painel', painelRouter);
 
 // Rota de webhook para receber mensagens do Z-API
-app.post('/webhook', webhookLimiter, async (req, res) => {
+app.post('/tenant/:tenantId/webhook', tenantMiddleware, webhookLimiter, async (req, res) => {
   try {
     console.log('📨 Mensagem recebida:', JSON.stringify(req.body, null, 2));
     
@@ -93,7 +94,7 @@ app.post('/webhook', webhookLimiter, async (req, res) => {
       return res.status(400).send('Mensagem inválida');
     }
 
-    console.log(`🧠 Processando mensagem do usuário ${userPhone}: "${userMessage}"`);
+    console.log(`🧠 Processando mensagem do usuário ${userPhone}: "${userMessage}" (tenant: ${req.tenantId})`);
 
     // Se houver atendimento humano pendente ou em andamento, não responder para evitar conflito
     try {
@@ -253,7 +254,7 @@ app.listen(PORT, () => {
   console.log('🚀 Servidor iniciado com sucesso!');
   console.log(`📡 Porta: ${PORT}`);
   console.log(`🌐 URL: http://localhost:${PORT}`);
-  console.log(`📨 Webhook: http://localhost:${PORT}/webhook`);
+  console.log(`📨 Webhook: http://localhost:${PORT}/tenant/<tenantId>/webhook`);
   console.log(`🧪 Teste: http://localhost:${PORT}/test`);
   console.log(`📊 Status: http://localhost:${PORT}/status`);
   console.log('✅ Sistema pronto para receber mensagens!');

--- a/middlewares/tenantMiddleware.js
+++ b/middlewares/tenantMiddleware.js
@@ -1,0 +1,15 @@
+const allowedTenants = (process.env.TENANT_IDS || '')
+  .split(',')
+  .map((t) => t.trim())
+  .filter(Boolean);
+
+module.exports = function tenantMiddleware(req, res, next) {
+  const { tenantId } = req.params;
+
+  if (!tenantId || !allowedTenants.includes(tenantId)) {
+    return res.status(404).json({ error: 'Tenant not found' });
+  }
+
+  req.tenantId = tenantId;
+  next();
+};


### PR DESCRIPTION
## Summary
- move webhook endpoint to `/tenant/:tenantId/webhook`
- validate tenants via new middleware and inject id into request
- document new environment variable and endpoint path

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ab6ce385288320a90c55feceb9ea8b