### PR TITLE
Add tenant service with caching and tenants table docs

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -134,6 +134,22 @@ CREATE TABLE notifications (
 );
 ```
 
+### 9. Tabela `tenants`
+Armazena credenciais e metadados para cada clínica/tenant.
+```sql
+CREATE TABLE tenants (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(200) NOT NULL,
+  zapi_instance_id VARCHAR(100),
+  zapi_token VARCHAR(255),
+  zapi_client_token VARCHAR(255),
+  gestaods_token VARCHAR(255),
+  dashboard_api_key VARCHAR(255),
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+```
+
 ## 🔐 Configuração de Políticas RLS (Row Level Security)
 
 Para desenvolvimento, você pode desabilitar o RLS temporariamente:

--- a/check-tables.js
+++ b/check-tables.js
@@ -10,13 +10,14 @@ async function checkTables() {
   
   const requiredTables = [
     'appointment_requests',
-    'reschedule_requests', 
+    'reschedule_requests',
     'cancel_requests',
     'waitlist',
     'secretary_tickets',
     'patients',
     'messages',
-    'notifications'
+    'notifications',
+    'tenants'
   ];
   
   for (const tableName of requiredTables) {

--- a/services/tenantService.js
+++ b/services/tenantService.js
@@ -1,0 +1,45 @@
+const { supabase } = require('./supabaseClient');
+
+// Cache simples em memória para armazenar configurações dos tenants
+const tenantCache = new Map();
+
+/**
+ * Busca as configurações de um tenant no Supabase.
+ * Os resultados são armazenados em cache para evitar consultas repetidas.
+ * @param {string|number} tenantId - Identificador do tenant
+ * @returns {Promise<Object>} Configurações do tenant
+ */
+async function getTenantConfig(tenantId) {
+  if (!tenantId) {
+    throw new Error('tenantId é obrigatório');
+  }
+
+  // Retorna do cache se já estiver disponível
+  if (tenantCache.has(tenantId)) {
+    return tenantCache.get(tenantId);
+  }
+
+  if (!supabase) {
+    throw new Error('Cliente Supabase não configurado');
+  }
+
+  const { data, error } = await supabase
+    .from('tenants')
+    .select('*')
+    .eq('id', tenantId)
+    .single();
+
+  if (error) {
+    throw new Error(`Erro ao buscar tenant: ${error.message}`);
+  }
+
+  // Armazena resultado no cache
+  tenantCache.set(tenantId, data);
+
+  return data;
+}
+
+module.exports = {
+  getTenantConfig,
+  _tenantCache: tenantCache // exportado para facilitar testes
+};


### PR DESCRIPTION
## Summary
- add service to fetch tenant configuration with in-memory cache
- document tenants table and include it in table check script

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ab70e8d7fc83209a7282af95a6b4d9