### PR TITLE
feat: pass tenant config to sendMessage

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -1,5 +1,12 @@
 const { flowController } = require('../services/flowController');
 const zapiService = require('../services/zapiService');
+require('dotenv').config();
+
+const tenantConfig = {
+  instanceId: process.env.ZAPI_INSTANCE_ID,
+  token: process.env.ZAPI_TOKEN,
+  clientToken: process.env.ZAPI_CLIENT_TOKEN
+};
 
 exports.handleIncomingMessage = async (req, res) => {
   try {
@@ -16,11 +23,11 @@ exports.handleIncomingMessage = async (req, res) => {
     const resposta = await flowController(userMessage, userPhone);
 
     // Envia mensagem ao usuário
-    await zapiService.sendMessage(userPhone, resposta);
+    await zapiService.sendMessage(tenantConfig, userPhone, resposta);
 
     res.status(200).send('Mensagem processada');
   } catch (err) {
     console.error('[Erro na controller]', err);
     res.status(500).send('Erro no processamento da mensagem');
   }
-}; 
+};

--- a/index.js
+++ b/index.js
@@ -9,6 +9,12 @@ const zapiService = require('./services/zapiService');
 const { supabase } = require('./services/supabaseClient');
 const LOG_MESSAGES = process.env.LOG_MESSAGES || 'key';
 
+const tenantConfig = {
+  instanceId: process.env.ZAPI_INSTANCE_ID,
+  token: process.env.ZAPI_TOKEN,
+  clientToken: process.env.ZAPI_CLIENT_TOKEN
+};
+
 const app = express();
 const PORT = process.env.PORT || 3000;
 
@@ -129,7 +135,7 @@ app.post('/webhook', webhookLimiter, async (req, res) => {
     console.log(`📤 Enviando resposta para ${userPhone}:`, resposta);
 
     // Envia a resposta via Z-API
-    await zapiService.sendMessage(userPhone, resposta);
+      await zapiService.sendMessage(tenantConfig, userPhone, resposta);
 
     // Log saída (somente se habilitado)
     if (LOG_MESSAGES === 'all') {

--- a/services/zapiService.js
+++ b/services/zapiService.js
@@ -3,10 +3,12 @@ require('dotenv').config();
 
 const { ZAPI_INSTANCE_ID, ZAPI_TOKEN, ZAPI_CLIENT_TOKEN } = process.env;
 
-async function sendMessage(phone, message) {
+async function sendMessage(tenantConfig, phone, message) {
   try {
+    const { instanceId, token, clientToken } = tenantConfig;
+
     // Formato correto da API Z-API
-    const url = `https://api.z-api.io/instances/${ZAPI_INSTANCE_ID}/token/${ZAPI_TOKEN}/send-text`;
+    const url = `https://api.z-api.io/instances/${instanceId}/token/${token}/send-text`;
 
     const payload = {
       phone: phone,
@@ -19,7 +21,7 @@ async function sendMessage(phone, message) {
     const response = await axios.post(url, payload, {
       headers: {
         'Content-Type': 'application/json',
-        'Client-Token': ZAPI_CLIENT_TOKEN
+        'Client-Token': clientToken
       }
     });
 
@@ -49,5 +51,4 @@ async function getStatus() {
     throw new Error('Falha ao verificar status do Z-API');
   }
 }
-
-module.exports = { sendMessage, getStatus }; 
+module.exports = { sendMessage, getStatus };


### PR DESCRIPTION
## Summary
- accept tenant-specific tokens when sending messages
- update index and controller to supply tenant config

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ab727c9c1083209410ec6b03d4251e