### PR TITLE
feat: pass tenant token

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const { flowController } = require('./services/flowController');
 const zapiService = require('./services/zapiService');
 const { supabase } = require('./services/supabaseClient');
 const LOG_MESSAGES = process.env.LOG_MESSAGES || 'key';
+const TENANT_CONFIG = { gestaodsToken: process.env.GESTAODS_TOKEN };
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -118,7 +119,7 @@ app.post('/webhook', webhookLimiter, async (req, res) => {
     }
 
     // Processa o fluxo da conversa usando o flowController
-    const resposta = await flowController(userMessage, userPhone);
+    const resposta = await flowController(userMessage, userPhone, TENANT_CONFIG);
 
     // Se o fluxo decidir não responder (null/undefined/empty), não enviar mensagem
     if (!resposta) {
@@ -156,7 +157,7 @@ app.get('/test', async (req, res) => {
     const testPhone = '5511999999999';
     
     console.log('🧪 Testando o sistema...');
-    const resposta = await flowController(testMessage, testPhone);
+    const resposta = await flowController(testMessage, testPhone, TENANT_CONFIG);
     
     res.json({
       success: true,
@@ -202,7 +203,7 @@ app.post('/test-webhook', async (req, res) => {
       });
     }
     
-    const resposta = await flowController(userMessage, userPhone);
+    const resposta = await flowController(userMessage, userPhone, TENANT_CONFIG);
     
     res.json({
       success: true,

--- a/services/apiGestaoService.js
+++ b/services/apiGestaoService.js
@@ -1,5 +1,4 @@
 const axios = require('axios');
-require('dotenv').config();
 
 /**
  * Cadastra um novo paciente no sistema GestãoDS
@@ -10,12 +9,12 @@ require('dotenv').config();
  * @param {string} paciente.celular - Celular do paciente (apenas números)
  * @returns {Object} Resultado da operação
  */
-async function cadastrarPacienteNoGestao(paciente) {
+async function cadastrarPacienteNoGestao(paciente, gestaodsToken) {
   try {
     console.log(`[API GestaODS] Tentando cadastrar paciente: ${paciente.nome_completo} (CPF: ${paciente.cpf})`);
-    const token = process.env.GESTAODS_TOKEN;
+    const token = gestaodsToken;
     if (!token) {
-      console.warn('[API GestaODS] GESTAODS_TOKEN não configurado no ambiente');
+      console.warn('[API GestaODS] Token do GestãoDS não fornecido');
       return { sucesso: false, mensagem: 'Token de integração não configurado' };
     }
 

--- a/services/flowController.js
+++ b/services/flowController.js
@@ -421,7 +421,7 @@ function normalizeName(name) {
     .replace(/\s+/g, ' ');
 }
 
-async function visualizarAgendamentosPorNome(nomePaciente, userPhone) {
+async function visualizarAgendamentosPorNome(nomePaciente, userPhone, gestaodsToken) {
   try {
     const hoje = new Date();
     const dataInicial = hoje.toLocaleDateString('pt-BR'); // ex: 04/08/2025
@@ -430,7 +430,7 @@ async function visualizarAgendamentosPorNome(nomePaciente, userPhone) {
     dataFinal.setMonth(dataFinal.getMonth() + 3);
     const dataFinalFormatada = dataFinal.toLocaleDateString('pt-BR'); // ex: 04/11/2025
 
-    const tokenListagem = process.env.GESTAODS_TOKEN;
+    const tokenListagem = gestaodsToken;
     const url = `https://apidev.gestaods.com.br/api/dados-agendamento/listagem/${tokenListagem}`;
 
     console.log('[VisualizarAgendamentosPorNome] Chamando API:', url, {
@@ -813,7 +813,7 @@ async function handleAguardandoCpf(phone, message) {
     upsertPatient({ cpf: message, name: context.nome, phone, email: context.email });
 
     // Busca o paciente usando o gestaodsService
-    const token = process.env.GESTAODS_TOKEN;
+    const token = gestaodsToken;
     const paciente = await gestaodsService.verificarPaciente(token, message);
 
     if (!paciente) {
@@ -1006,7 +1006,7 @@ async function handleConfirmandoCadastro(phone, message) {
           cpf: context.cpf,
           email: context.email,
           celular: context.celular
-        });
+        }, gestaodsToken);
 
         if (resultadoCadastro.sucesso) {
           console.log(`[FLOW] Paciente cadastrado com sucesso na API: ${context.nome}`);
@@ -1141,7 +1141,7 @@ async function handleConfirmandoPaciente(phone, message) {
       return '❗ Por favor, digite um nome válido com pelo menos 3 letras.';
     }
 
-    const mensagem = await visualizarAgendamentosPorNome(nome, phone);
+    const mensagem = await visualizarAgendamentosPorNome(nome, phone, gestaodsToken);
 
     if (mensagem.includes('📭 Você não possui agendamentos')) {
       setState(phone, 'finalizado');
@@ -1167,7 +1167,7 @@ async function handleConfirmandoPaciente(phone, message) {
           try {
             // Adiciona o token ao contexto se não existir
             if (!context.token) {
-              context.token = process.env.GESTAODS_TOKEN;
+              context.token = gestaodsToken;
               setContext(phone, context);
             }
 
@@ -1552,7 +1552,8 @@ function handleEstadoFinal(phone, message) {
 }
 
 // 🧠 Função principal do flowController
-async function flowController(message, phone) {
+async function flowController(message, phone, tenantConfig = {}) {
+  const { gestaodsToken } = tenantConfig;
   const state = getState(phone);
   console.log(`🧠 Processando mensagem do usuário ${phone} no estado: ${state}`);
   try { await logMessageToSupabase(phone, 'in', message); } catch {}
@@ -2135,9 +2136,9 @@ async function handleOpcaoReagendarCancelar(phone, message) {
 
 
 // 📋 Função modificada para listar agendamentos com opção de edição
-async function listarAgendamentosPorCPFComEdicao(context, phone) {
+async function listarAgendamentosPorCPFComEdicao(context, phone, gestaodsToken) {
   try {
-    const token = context.token || process.env.GESTAODS_TOKEN;
+    const token = context.token || gestaodsToken;
     const cpf = context.cpf;
 
     if (!token || !cpf) {

--- a/utils/buscarPaciente.js
+++ b/utils/buscarPaciente.js
@@ -1,9 +1,9 @@
 // utils/buscarPaciente.js
 const axios = require('axios');
-require('dotenv').config();
 
-async function buscarPacientePorCPF(cpf) {
-  const token = process.env.GESTAODS_TOKEN;
+// Busca paciente pelo CPF usando o token fornecido pelo tenant
+async function buscarPacientePorCPF(cpf, gestaodsToken) {
+  const token = gestaodsToken;
   const url = `https://apidev.gestaods.com.br/api/paciente/${token}/${cpf}/`;
 
   try {
@@ -29,8 +29,8 @@ async function buscarPacientePorCPF(cpf) {
 }
 
 // Função para buscar dados detalhados do paciente
-async function buscarDadosDetalhadosPaciente(cpf) {
-  const token = process.env.GESTAODS_TOKEN;
+async function buscarDadosDetalhadosPaciente(cpf, gestaodsToken) {
+  const token = gestaodsToken;
   
   // Tenta diferentes endpoints para buscar dados detalhados
   const urls = [


### PR DESCRIPTION
## Summary
- accept tenant token in patient lookup utilities
- get GestãoDS token from tenant in patient registration and flow controller
- pass tenant configuration through server entry point

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ab728262608320b0eaf65d9135098a