### PR TITLE
feat: add tenant management

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -9,6 +9,7 @@ import Espera from './pages/Espera';
 import Secretaria from './pages/Secretaria';
 import Pacientes from './pages/Pacientes';
 import './App.css';
+import Tenants from './pages/Tenants';
 
 function App() {
   return (
@@ -26,6 +27,7 @@ function App() {
               <Route path="/espera" element={<Espera />} />
               <Route path="/secretaria" element={<Secretaria />} />
               <Route path="/pacientes" element={<Pacientes />} />
+              <Route path="/tenants" element={<Tenants />} />
             </Routes>
           </div>
         </div>

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -84,8 +84,14 @@ export default function Sidebar() {
               <span className="text">Pacientes Cadastrados</span>
             </Link>
           </li>
+          <li className={isActive('/tenants')}>
+            <Link to="/tenants" data-title="Tenants">
+              <span className="icon">⚙️</span>
+              <span className="text">Tenants</span>
+            </Link>
+          </li>
         </ul>
       </nav>
     </div>
   );
-} 
+}

--- a/dashboard/src/pages/Tenants.css
+++ b/dashboard/src/pages/Tenants.css
@@ -1,0 +1,19 @@
+.tenants-page {
+  padding: 20px;
+}
+
+.tenant-form {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.tenant-form input {
+  padding: 5px;
+}
+
+.tenant-list li {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 5px;
+}

--- a/dashboard/src/pages/Tenants.jsx
+++ b/dashboard/src/pages/Tenants.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import tenantService from '../services/tenantService';
+import './Tenants.css';
+
+export default function Tenants() {
+  const [tenants, setTenants] = useState([]);
+  const [form, setForm] = useState({ id: null, name: '', zapiKey: '', gestaoKey: '' });
+
+  const load = async () => {
+    const data = await tenantService.list();
+    setTenants(data);
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const payload = { name: form.name, zapiKey: form.zapiKey, gestaoKey: form.gestaoKey };
+    if (form.id) {
+      await tenantService.update(form.id, payload);
+    } else {
+      await tenantService.create(payload);
+    }
+    setForm({ id: null, name: '', zapiKey: '', gestaoKey: '' });
+    await load();
+  };
+
+  const edit = (t) => {
+    setForm({ id: t.id, name: t.name || '', zapiKey: t.zapi_key || '', gestaoKey: t.gestao_key || '' });
+  };
+
+  return (
+    <div className="tenants-page">
+      <h2>Gerenciar Tenants</h2>
+      <form onSubmit={handleSubmit} className="tenant-form">
+        <input
+          type="text"
+          placeholder="Nome"
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Z-API Key"
+          value={form.zapiKey}
+          onChange={(e) => setForm({ ...form, zapiKey: e.target.value })}
+          required
+        />
+        <input
+          type="text"
+          placeholder="Gestão Key"
+          value={form.gestaoKey}
+          onChange={(e) => setForm({ ...form, gestaoKey: e.target.value })}
+          required
+        />
+        <button type="submit">{form.id ? 'Atualizar' : 'Cadastrar'}</button>
+      </form>
+
+      <ul className="tenant-list">
+        {tenants.map((t) => (
+          <li key={t.id}>
+            <span>{t.name}</span>
+            <button onClick={() => edit(t)}>Editar</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/dashboard/src/services/tenantService.js
+++ b/dashboard/src/services/tenantService.js
@@ -1,0 +1,26 @@
+import api from './api';
+
+const tenantService = {
+  list: async () => {
+    const res = await api.get('/tenants');
+    return res.data;
+  },
+  get: async (id) => {
+    const res = await api.get(`/tenants/${id}`);
+    return res.data;
+  },
+  create: async (tenant) => {
+    const res = await api.post('/tenants', tenant);
+    return res.data;
+  },
+  update: async (id, tenant) => {
+    const res = await api.put(`/tenants/${id}`, tenant);
+    return res.data;
+  },
+  remove: async (id) => {
+    const res = await api.delete(`/tenants/${id}`);
+    return res.data;
+  }
+};
+
+export default tenantService;

--- a/index.js
+++ b/index.js
@@ -45,6 +45,10 @@ app.get('/', (req, res) => {
 const painelRouter = require('./routes/painel');
 app.use('/api/painel', painelRouter);
 
+// Tenants management
+const tenantRouter = require('./routes/tenants');
+app.use('/api/tenants', tenantRouter);
+
 // Rota de webhook para receber mensagens do Z-API
 app.post('/webhook', webhookLimiter, async (req, res) => {
   try {

--- a/routes/tenants.js
+++ b/routes/tenants.js
@@ -1,0 +1,61 @@
+const express = require('express');
+const router = express.Router();
+const tenantService = require('../services/tenantService');
+
+// List tenants
+router.get('/', async (req, res) => {
+  try {
+    const tenants = await tenantService.getTenants();
+    res.json(tenants);
+  } catch (error) {
+    console.error('[tenants] list error:', error.message);
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+// Get single tenant
+router.get('/:id', async (req, res) => {
+  try {
+    const tenant = await tenantService.getTenant(req.params.id);
+    if (!tenant) return res.status(404).json({ error: 'not_found' });
+    res.json(tenant);
+  } catch (error) {
+    console.error('[tenants] get error:', error.message);
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+// Create tenant
+router.post('/', async (req, res) => {
+  try {
+    const tenant = await tenantService.createTenant(req.body);
+    res.status(201).json(tenant);
+  } catch (error) {
+    console.error('[tenants] create error:', error.message);
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+// Update tenant
+router.put('/:id', async (req, res) => {
+  try {
+    const tenant = await tenantService.updateTenant(req.params.id, req.body);
+    res.json(tenant);
+  } catch (error) {
+    console.error('[tenants] update error:', error.message);
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+// Delete tenant
+router.delete('/:id', async (req, res) => {
+  try {
+    await tenantService.deleteTenant(req.params.id);
+    res.json({ success: true });
+  } catch (error) {
+    console.error('[tenants] delete error:', error.message);
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+module.exports = router;

--- a/services/tenantService.js
+++ b/services/tenantService.js
@@ -1,0 +1,53 @@
+const { supabase } = require('./supabaseClient');
+
+async function getTenants() {
+  if (!supabase) return [];
+  const { data, error } = await supabase.from('tenants').select('*').order('id');
+  if (error) throw error;
+  return data;
+}
+
+async function getTenant(id) {
+  if (!supabase) return null;
+  const { data, error } = await supabase.from('tenants').select('*').eq('id', id).single();
+  if (error) throw error;
+  return data;
+}
+
+async function createTenant(tenant) {
+  if (!supabase) return null;
+  const { data, error } = await supabase
+    .from('tenants')
+    .insert({ name: tenant.name, zapi_key: tenant.zapiKey, gestao_key: tenant.gestaoKey })
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+async function updateTenant(id, tenant) {
+  if (!supabase) return null;
+  const { data, error } = await supabase
+    .from('tenants')
+    .update({ name: tenant.name, zapi_key: tenant.zapiKey, gestao_key: tenant.gestaoKey })
+    .eq('id', id)
+    .select()
+    .single();
+  if (error) throw error;
+  return data;
+}
+
+async function deleteTenant(id) {
+  if (!supabase) return false;
+  const { error } = await supabase.from('tenants').delete().eq('id', id);
+  if (error) throw error;
+  return true;
+}
+
+module.exports = {
+  getTenants,
+  getTenant,
+  createTenant,
+  updateTenant,
+  deleteTenant,
+};


### PR DESCRIPTION
## Summary
- add Supabase tenant service and REST endpoints
- expose tenant API and frontend management page

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, Empty block statement, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68ab748747848320ad87296a657cfc9e