### PR TITLE
Add tenants table migration and tenant service cache

### DIFF
--- a/database/migrations/001_create_tenants_table.sql
+++ b/database/migrations/001_create_tenants_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE tenants (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name VARCHAR(100) NOT NULL,
+  api_key TEXT NOT NULL,
+  api_secret TEXT,
+  metadata JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/services/tenantService.js
+++ b/services/tenantService.js
@@ -1,0 +1,31 @@
+const { supabase } = require('./supabaseClient');
+
+const tenantCache = new Map();
+
+async function getTenantConfig(tenantId) {
+  if (tenantCache.has(tenantId)) {
+    return tenantCache.get(tenantId);
+  }
+
+  const { data, error } = await supabase
+    .from('tenants')
+    .select('*')
+    .eq('id', tenantId)
+    .single();
+
+  if (error) {
+    throw new Error(`Erro ao buscar tenant ${tenantId}: ${error.message}`);
+  }
+
+  tenantCache.set(tenantId, data);
+  return data;
+}
+
+function clearTenantCache() {
+  tenantCache.clear();
+}
+
+module.exports = {
+  getTenantConfig,
+  clearTenantCache
+};


### PR DESCRIPTION
## Summary
- add SQL migration for tenants table with credential and metadata fields
- implement tenant service with per-request caching for tenant configurations

## Testing
- `npm test` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_b_68ab762e404483208974b3f5814cde74