### PR TITLE
refactor: inject tenant config into services

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -1,5 +1,6 @@
 const { flowController } = require('../services/flowController');
 const zapiService = require('../services/zapiService');
+const tenantConfig = require('../tenantConfig');
 
 exports.handleIncomingMessage = async (req, res) => {
   try {
@@ -13,14 +14,15 @@ exports.handleIncomingMessage = async (req, res) => {
     }
 
     // Processa o fluxo da conversa usando o flowController
-    const resposta = await flowController(userMessage, userPhone);
+    const resposta = await flowController(tenantConfig, userMessage, userPhone);
 
     // Envia mensagem ao usuário
-    await zapiService.sendMessage(userPhone, resposta);
+    await zapiService.sendMessage(tenantConfig, userPhone, resposta);
 
     res.status(200).send('Mensagem processada');
   } catch (err) {
     console.error('[Erro na controller]', err);
     res.status(500).send('Erro no processamento da mensagem');
   }
-}; 
+};
+

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser');
 const cors = require('cors');
 const rateLimit = require('express-rate-limit');
 require('dotenv').config();
+const tenantConfig = require('./tenantConfig');
 
 const { flowController } = require('./services/flowController');
 const zapiService = require('./services/zapiService');
@@ -118,7 +119,7 @@ app.post('/webhook', webhookLimiter, async (req, res) => {
     }
 
     // Processa o fluxo da conversa usando o flowController
-    const resposta = await flowController(userMessage, userPhone);
+    const resposta = await flowController(tenantConfig, userMessage, userPhone);
 
     // Se o fluxo decidir não responder (null/undefined/empty), não enviar mensagem
     if (!resposta) {
@@ -129,7 +130,7 @@ app.post('/webhook', webhookLimiter, async (req, res) => {
     console.log(`📤 Enviando resposta para ${userPhone}:`, resposta);
 
     // Envia a resposta via Z-API
-    await zapiService.sendMessage(userPhone, resposta);
+    await zapiService.sendMessage(tenantConfig, userPhone, resposta);
 
     // Log saída (somente se habilitado)
     if (LOG_MESSAGES === 'all') {
@@ -156,7 +157,7 @@ app.get('/test', async (req, res) => {
     const testPhone = '5511999999999';
     
     console.log('🧪 Testando o sistema...');
-    const resposta = await flowController(testMessage, testPhone);
+    const resposta = await flowController(tenantConfig, testMessage, testPhone);
     
     res.json({
       success: true,
@@ -202,7 +203,7 @@ app.post('/test-webhook', async (req, res) => {
       });
     }
     
-    const resposta = await flowController(userMessage, userPhone);
+    const resposta = await flowController(tenantConfig, userMessage, userPhone);
     
     res.json({
       success: true,
@@ -224,7 +225,7 @@ app.post('/test-webhook', async (req, res) => {
 // Rota para verificar status do Z-API
 app.get('/status', async (req, res) => {
   try {
-    const status = await zapiService.getStatus();
+    const status = await zapiService.getStatus(tenantConfig);
     res.json({
       success: true,
       status,

--- a/services/apiGestaoService.js
+++ b/services/apiGestaoService.js
@@ -1,8 +1,8 @@
 const axios = require('axios');
-require('dotenv').config();
 
 /**
  * Cadastra um novo paciente no sistema GestãoDS
+ * @param {Object} tenantConfig - Configurações do tenant
  * @param {Object} paciente - Dados do paciente
  * @param {string} paciente.nome_completo - Nome completo do paciente
  * @param {string} paciente.cpf - CPF do paciente (apenas números)
@@ -10,16 +10,18 @@ require('dotenv').config();
  * @param {string} paciente.celular - Celular do paciente (apenas números)
  * @returns {Object} Resultado da operação
  */
-async function cadastrarPacienteNoGestao(paciente) {
+async function cadastrarPacienteNoGestao(tenantConfig, paciente) {
   try {
     console.log(`[API GestaODS] Tentando cadastrar paciente: ${paciente.nome_completo} (CPF: ${paciente.cpf})`);
-    const token = process.env.GESTAODS_TOKEN;
+    const token = tenantConfig.gestaodsToken;
     if (!token) {
-      console.warn('[API GestaODS] GESTAODS_TOKEN não configurado no ambiente');
+      console.warn('[API GestaODS] GESTAODS_TOKEN não configurado no tenantConfig');
       return { sucesso: false, mensagem: 'Token de integração não configurado' };
     }
 
-    const response = await axios.post('https://apidev.gestaods.com.br/api/paciente/cadastrar/', {
+    const baseUrl = tenantConfig.gestaodsBaseUrl || 'https://apidev.gestaods.com.br';
+
+    const response = await axios.post(`${baseUrl}/api/paciente/cadastrar/`, {
       nome_completo: paciente.nome_completo,
       cpf: paciente.cpf,
       email: paciente.email,
@@ -33,7 +35,7 @@ async function cadastrarPacienteNoGestao(paciente) {
     });
 
     console.log(`[API GestaODS] Paciente cadastrado com sucesso:`, response.data);
-    
+
     if (response.status === 201) {
       return { sucesso: true };
     } else {
@@ -50,4 +52,5 @@ async function cadastrarPacienteNoGestao(paciente) {
 
 module.exports = {
   cadastrarPacienteNoGestao
-}; 
+};
+

--- a/services/flowController.js
+++ b/services/flowController.js
@@ -269,9 +269,9 @@ function validarContextoAgendamento(context) {
 }
 
 // 🔍 Função para buscar datas disponíveis de forma segura
-async function buscarDatasDisponiveis(token) {
+async function buscarDatasDisponiveis(tenantConfig) {
   try {
-    const diasResponse = await gestaodsService.buscarDiasDisponiveis(token);
+    const diasResponse = await gestaodsService.buscarDiasDisponiveis(tenantConfig);
 
     const dias = Array.isArray(diasResponse?.data)
       ? diasResponse.data
@@ -294,9 +294,9 @@ async function buscarDatasDisponiveis(token) {
 }
 
 // 🕐 Função para buscar horários disponíveis de forma segura
-async function buscarHorariosDisponiveis(token, dataSelecionada) {
+async function buscarHorariosDisponiveis(tenantConfig, dataSelecionada) {
   try {
-    const horariosResponse = await gestaodsService.buscarHorariosDisponiveis(token, dataSelecionada);
+    const horariosResponse = await gestaodsService.buscarHorariosDisponiveis(tenantConfig, dataSelecionada);
 
     let horarios = Array.isArray(horariosResponse?.data)
       ? horariosResponse.data
@@ -421,7 +421,7 @@ function normalizeName(name) {
     .replace(/\s+/g, ' ');
 }
 
-async function visualizarAgendamentosPorNome(nomePaciente, userPhone) {
+async function visualizarAgendamentosPorNome(tenantConfig, nomePaciente, userPhone) {
   try {
     const hoje = new Date();
     const dataInicial = hoje.toLocaleDateString('pt-BR'); // ex: 04/08/2025
@@ -430,8 +430,9 @@ async function visualizarAgendamentosPorNome(nomePaciente, userPhone) {
     dataFinal.setMonth(dataFinal.getMonth() + 3);
     const dataFinalFormatada = dataFinal.toLocaleDateString('pt-BR'); // ex: 04/11/2025
 
-    const tokenListagem = process.env.GESTAODS_TOKEN;
-    const url = `https://apidev.gestaods.com.br/api/dados-agendamento/listagem/${tokenListagem}`;
+    const tokenListagem = tenantConfig.gestaodsToken;
+    const baseUrl = tenantConfig.gestaodsBaseUrl || 'https://apidev.gestaods.com.br';
+    const url = `${baseUrl}/api/dados-agendamento/listagem/${tokenListagem}`;
 
     console.log('[VisualizarAgendamentosPorNome] Chamando API:', url, {
       data_inicial: dataInicial,
@@ -813,8 +814,7 @@ async function handleAguardandoCpf(phone, message) {
     upsertPatient({ cpf: message, name: context.nome, phone, email: context.email });
 
     // Busca o paciente usando o gestaodsService
-    const token = process.env.GESTAODS_TOKEN;
-    const paciente = await gestaodsService.verificarPaciente(token, message);
+    const paciente = await gestaodsService.verificarPaciente(tenantConfig, message);
 
     if (!paciente) {
       setState(phone, 'aguardando_nome');
@@ -1001,7 +1001,7 @@ async function handleConfirmandoCadastro(phone, message) {
       try {
         console.log(`[FLOW] Tentando cadastrar paciente: ${context.nome} (CPF: ${context.cpf})`);
         
-        const resultadoCadastro = await cadastrarPacienteNoGestao({
+        const resultadoCadastro = await cadastrarPacienteNoGestao(tenantConfig, {
           nome_completo: context.nome,
           cpf: context.cpf,
           email: context.email,
@@ -1141,7 +1141,7 @@ async function handleConfirmandoPaciente(phone, message) {
       return '❗ Por favor, digite um nome válido com pelo menos 3 letras.';
     }
 
-    const mensagem = await visualizarAgendamentosPorNome(nome, phone);
+    const mensagem = await visualizarAgendamentosPorNome(tenantConfig, nome, phone);
 
     if (mensagem.includes('📭 Você não possui agendamentos')) {
       setState(phone, 'finalizado');
@@ -1167,12 +1167,12 @@ async function handleConfirmandoPaciente(phone, message) {
           try {
             // Adiciona o token ao contexto se não existir
             if (!context.token) {
-              context.token = process.env.GESTAODS_TOKEN;
+              context.token = tenantConfig.gestaodsToken;
               setContext(phone, context);
             }
 
             // Consulta à API oficial usando função segura
-            const dias = await buscarDatasDisponiveis(context.token);
+            const dias = await buscarDatasDisponiveis(tenantConfig);
 
             if (!dias || dias.length === 0) {
               return (
@@ -1307,7 +1307,7 @@ async function handleConfirmandoAgendamento(phone, message) {
         console.log("[FlowController] Verificação: data_fim_agendamento deve ser 20 minutos após data_agendamento");
 
         // Chamada para a API (lança erro se falhar)
-        await gestaodsService.agendarConsulta(payload);
+        await gestaodsService.agendarConsulta(tenantConfig, payload);
 
         // Registrar aprovação automática na dashboard (opção B)
         console.log(`[FLOW] Tentando registrar agendamento na dashboard...`);
@@ -1427,7 +1427,7 @@ async function handleEscolhendoData(phone, message) {
 
   try {
     // Consulta à API oficial usando função segura
-    const horarios = await buscarHorariosDisponiveis(context.token, dataSelecionada);
+    const horarios = await buscarHorariosDisponiveis(tenantConfig, dataSelecionada);
 
     if (!horarios || horarios.length === 0) {
       return (
@@ -1552,7 +1552,7 @@ function handleEstadoFinal(phone, message) {
 }
 
 // 🧠 Função principal do flowController
-async function flowController(message, phone) {
+async function flowController(tenantConfig, message, phone) {
   const state = getState(phone);
   console.log(`🧠 Processando mensagem do usuário ${phone} no estado: ${state}`);
   try { await logMessageToSupabase(phone, 'in', message); } catch {}
@@ -1825,7 +1825,7 @@ async function flowController(message, phone) {
 
 // ✅ FlowController Corrigido
 const FlowController = {
-  async agendarConsulta(context) {
+  async agendarConsulta(tenantConfig, context) {
     try {
       // Validar se o contexto está completo
       if (!context?.token || !context?.cpf || !context?.dataSelecionada || !context?.horaSelecionada) {
@@ -1851,7 +1851,7 @@ const FlowController = {
       console.log("[FlowController] Verificação: data_fim_agendamento deve ser 20 minutos após data_agendamento");
 
       // Chamada para a API
-      const resposta = await gestaodsService.agendarConsulta(payload);
+      const resposta = await gestaodsService.agendarConsulta(tenantConfig, payload);
 
       if (resposta?.status === 200 || resposta?.status === 201) {
         console.log("[FlowController] Consulta agendada com sucesso:", resposta.data);
@@ -2135,9 +2135,9 @@ async function handleOpcaoReagendarCancelar(phone, message) {
 
 
 // 📋 Função modificada para listar agendamentos com opção de edição
-async function listarAgendamentosPorCPFComEdicao(context, phone) {
+async function listarAgendamentosPorCPFComEdicao(tenantConfig, context, phone) {
   try {
-    const token = context.token || process.env.GESTAODS_TOKEN;
+    const token = context.token || tenantConfig.gestaodsToken;
     const cpf = context.cpf;
 
     if (!token || !cpf) {
@@ -2154,7 +2154,8 @@ async function listarAgendamentosPorCPFComEdicao(context, phone) {
     const dataInicial = moment().subtract(1, 'year').format('DD/MM/YYYY');
     const dataFinal = moment().add(1, 'year').format('DD/MM/YYYY');
 
-    const url = `https://apidev.gestaods.com.br/api/dados-agendamento/listagem/${token}`;
+    const baseUrl = tenantConfig.gestaodsBaseUrl || 'https://apidev.gestaods.com.br';
+    const url = `${baseUrl}/api/dados-agendamento/listagem/${token}`;
 
     console.log(`[listarAgendamentosPorCPFComEdicao] URL: ${url}`);
     console.log(`[listarAgendamentosPorCPFComEdicao] Parâmetros: data_inicial=${dataInicial}, data_final=${dataFinal}`);

--- a/services/gestaodsService.js
+++ b/services/gestaodsService.js
@@ -1,11 +1,12 @@
 const axios = require('axios');
-require('dotenv').config();
 
-const BASE_URL = 'https://apidev.gestaods.com.br';
+const DEFAULT_BASE_URL = 'https://apidev.gestaods.com.br';
 
-async function verificarPaciente(token, cpf) {
+async function verificarPaciente(tenantConfig, cpf) {
   try {
-    const url = `${BASE_URL}/api/paciente/${token}/${cpf}/`;
+    const baseUrl = tenantConfig.gestaodsBaseUrl || DEFAULT_BASE_URL;
+    const token = tenantConfig.gestaodsToken;
+    const url = `${baseUrl}/api/paciente/${token}/${cpf}/`;
     const response = await axios.get(url);
     return response.data;
   } catch (error) {
@@ -16,9 +17,11 @@ async function verificarPaciente(token, cpf) {
   }
 }
 
-async function buscarDiasDisponiveis(token) {
+async function buscarDiasDisponiveis(tenantConfig) {
   try {
-    const url = `${BASE_URL}/api/agendamento/dias-disponiveis/${token}`;
+    const baseUrl = tenantConfig.gestaodsBaseUrl || DEFAULT_BASE_URL;
+    const token = tenantConfig.gestaodsToken;
+    const url = `${baseUrl}/api/agendamento/dias-disponiveis/${token}`;
     const response = await axios.get(url);
     return response.data;
   } catch (error) {
@@ -27,9 +30,11 @@ async function buscarDiasDisponiveis(token) {
   }
 }
 
-async function buscarHorariosDisponiveis(token, data) {
+async function buscarHorariosDisponiveis(tenantConfig, data) {
   try {
-    const url = `${BASE_URL}/api/agendamento/horarios-disponiveis/${token}?data=${data}`;
+    const baseUrl = tenantConfig.gestaodsBaseUrl || DEFAULT_BASE_URL;
+    const token = tenantConfig.gestaodsToken;
+    const url = `${baseUrl}/api/agendamento/horarios-disponiveis/${token}?data=${data}`;
     const response = await axios.get(url);
     return response.data;
   } catch (error) {
@@ -38,9 +43,10 @@ async function buscarHorariosDisponiveis(token, data) {
   }
 }
 
-async function agendarConsulta(payload) {
+async function agendarConsulta(tenantConfig, payload) {
   try {
-    const url = `${BASE_URL}/api/agendamento/agendar/`;
+    const baseUrl = tenantConfig.gestaodsBaseUrl || DEFAULT_BASE_URL;
+    const url = `${baseUrl}/api/agendamento/agendar/`;
 
     // ✅ Validação dos campos obrigatórios
     if (!payload.token) {
@@ -56,14 +62,14 @@ async function agendarConsulta(payload) {
       throw new Error('Data de fim do agendamento é obrigatória');
     }
 
-    console.log('[GestãoDS] Enviando dados de agendamento:', JSON.stringify(payload, null, 2)); // ✅ debug útil
+    console.log('[GestãoDS] Enviando dados de agendamento:', JSON.stringify(payload, null, 2));
 
     const response = await axios.post(url, payload, {
       headers: {
         'Content-Type': 'application/json'
       }
     });
-    
+
     if (response.status === 201) {
       console.log('[GestãoDS] Agendamento realizado com sucesso');
       return response.data;
@@ -88,4 +94,5 @@ module.exports = {
   buscarDiasDisponiveis,
   buscarHorariosDisponiveis,
   agendarConsulta
-}; 
+};
+

--- a/services/zapiService.js
+++ b/services/zapiService.js
@@ -1,12 +1,10 @@
 const axios = require('axios');
-require('dotenv').config();
 
-const { ZAPI_INSTANCE_ID, ZAPI_TOKEN, ZAPI_CLIENT_TOKEN } = process.env;
-
-async function sendMessage(phone, message) {
+async function sendMessage(tenantConfig, phone, message) {
   try {
+    const { zapiInstanceId, zapiToken, zapiClientToken } = tenantConfig;
     // Formato correto da API Z-API
-    const url = `https://api.z-api.io/instances/${ZAPI_INSTANCE_ID}/token/${ZAPI_TOKEN}/send-text`;
+    const url = `https://api.z-api.io/instances/${zapiInstanceId}/token/${zapiToken}/send-text`;
 
     const payload = {
       phone: phone,
@@ -19,7 +17,7 @@ async function sendMessage(phone, message) {
     const response = await axios.post(url, payload, {
       headers: {
         'Content-Type': 'application/json',
-        'Client-Token': ZAPI_CLIENT_TOKEN
+        'Client-Token': zapiClientToken
       }
     });
 
@@ -33,15 +31,16 @@ async function sendMessage(phone, message) {
   }
 }
 
-async function getStatus() {
+async function getStatus(tenantConfig) {
   try {
-    const url = `https://api.z-api.io/instances/${ZAPI_INSTANCE_ID}/token/${ZAPI_TOKEN}/status`;
+    const { zapiInstanceId, zapiToken, zapiClientToken } = tenantConfig;
+    const url = `https://api.z-api.io/instances/${zapiInstanceId}/token/${zapiToken}/status`;
     const response = await axios.get(url, {
       headers: {
-        'Client-Token': ZAPI_CLIENT_TOKEN
+        'Client-Token': zapiClientToken
       }
     });
-    
+
     console.log('[Z-API] Status verificado');
     return response.data;
   } catch (error) {
@@ -50,4 +49,5 @@ async function getStatus() {
   }
 }
 
-module.exports = { sendMessage, getStatus }; 
+module.exports = { sendMessage, getStatus };
+

--- a/tenantConfig.js
+++ b/tenantConfig.js
@@ -1,0 +1,11 @@
+require('dotenv').config();
+
+const tenantConfig = {
+  zapiInstanceId: process.env.ZAPI_INSTANCE_ID,
+  zapiToken: process.env.ZAPI_TOKEN,
+  zapiClientToken: process.env.ZAPI_CLIENT_TOKEN,
+  gestaodsToken: process.env.GESTAODS_TOKEN,
+  gestaodsBaseUrl: process.env.GESTAODS_BASE_URL || 'https://apidev.gestaods.com.br'
+};
+
+module.exports = tenantConfig;


### PR DESCRIPTION
## Summary
- route tenantConfig through Z-API, GestãoDS, and Gestao API services
- update flow controller and callers to provide tenant config
- centralize environment values in tenantConfig module

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68ab78b429a88320be70215d2e679069