### PR TITLE
feat: manage tenants

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -8,6 +8,9 @@ import Cancelamentos from './pages/Cancelamentos';
 import Espera from './pages/Espera';
 import Secretaria from './pages/Secretaria';
 import Pacientes from './pages/Pacientes';
+import Tenants from './pages/Tenants';
+import TenantCreate from './pages/TenantCreate';
+import TenantEdit from './pages/TenantEdit';
 import './App.css';
 
 function App() {
@@ -26,6 +29,9 @@ function App() {
               <Route path="/espera" element={<Espera />} />
               <Route path="/secretaria" element={<Secretaria />} />
               <Route path="/pacientes" element={<Pacientes />} />
+              <Route path="/tenants" element={<Tenants />} />
+              <Route path="/tenants/new" element={<TenantCreate />} />
+              <Route path="/tenants/:id" element={<TenantEdit />} />
             </Routes>
           </div>
         </div>

--- a/dashboard/src/components/Sidebar.tsx
+++ b/dashboard/src/components/Sidebar.tsx
@@ -84,8 +84,14 @@ export default function Sidebar() {
               <span className="text">Pacientes Cadastrados</span>
             </Link>
           </li>
+          <li className={isActive('/tenants')}>
+            <Link to="/tenants" data-title="Tenants">
+              <span className="icon">🏢</span>
+              <span className="text">Tenants</span>
+            </Link>
+          </li>
         </ul>
       </nav>
     </div>
   );
-} 
+}

--- a/dashboard/src/pages/TenantCreate.jsx
+++ b/dashboard/src/pages/TenantCreate.jsx
@@ -1,0 +1,24 @@
+import { useNavigate } from 'react-router-dom';
+import TenantForm from './TenantForm';
+import { tenantService } from '../services/api';
+import './TenantForm.css';
+
+export default function TenantCreate() {
+  const navigate = useNavigate();
+
+  const handleSubmit = async (data) => {
+    try {
+      await tenantService.createTenant(data);
+      navigate('/tenants');
+    } catch (err) {
+      console.error('Erro ao criar tenant', err);
+    }
+  };
+
+  return (
+    <div className="tenant-create">
+      <h1>Novo Tenant</h1>
+      <TenantForm onSubmit={handleSubmit} />
+    </div>
+  );
+}

--- a/dashboard/src/pages/TenantEdit.jsx
+++ b/dashboard/src/pages/TenantEdit.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import TenantForm from './TenantForm';
+import { tenantService } from '../services/api';
+import './TenantForm.css';
+
+export default function TenantEdit() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [tenant, setTenant] = useState(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await tenantService.getTenant(id);
+        setTenant(data);
+      } catch (err) {
+        console.error('Erro ao carregar tenant', err);
+      }
+    };
+    load();
+  }, [id]);
+
+  const handleSubmit = async (data) => {
+    try {
+      await tenantService.updateTenant(id, data);
+      navigate('/tenants');
+    } catch (err) {
+      console.error('Erro ao atualizar tenant', err);
+    }
+  };
+
+  if (!tenant) {
+    return <div className="tenants"><div className="loading">Carregando...</div></div>;
+  }
+
+  return (
+    <div className="tenant-edit">
+      <h1>Editar Tenant</h1>
+      <TenantForm initialData={tenant} onSubmit={handleSubmit} />
+    </div>
+  );
+}

--- a/dashboard/src/pages/TenantForm.css
+++ b/dashboard/src/pages/TenantForm.css
@@ -1,0 +1,3 @@
+.tenant-form { max-width:400px; margin:0 auto; display:flex; flex-direction:column; gap:10px; }
+.form-group { display:flex; flex-direction:column; }
+.save-btn { align-self:flex-start; }

--- a/dashboard/src/pages/TenantForm.jsx
+++ b/dashboard/src/pages/TenantForm.jsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from 'react';
+import './TenantForm.css';
+
+export default function TenantForm({ initialData = {}, onSubmit }) {
+  const [name, setName] = useState('');
+  const [supabaseUrl, setSupabaseUrl] = useState('');
+  const [supabaseKey, setSupabaseKey] = useState('');
+
+  useEffect(() => {
+    setName(initialData.name || '');
+    setSupabaseUrl(initialData.credentials?.supabaseUrl || '');
+    setSupabaseKey(initialData.credentials?.supabaseKey || '');
+  }, [initialData]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSubmit({
+      name,
+      credentials: {
+        supabaseUrl,
+        supabaseKey
+      }
+    });
+  };
+
+  return (
+    <form className="tenant-form" onSubmit={handleSubmit}>
+      <div className="form-group">
+        <label>Nome</label>
+        <input value={name} onChange={(e) => setName(e.target.value)} required />
+      </div>
+      <div className="form-group">
+        <label>Supabase URL</label>
+        <input value={supabaseUrl} onChange={(e) => setSupabaseUrl(e.target.value)} />
+      </div>
+      <div className="form-group">
+        <label>Supabase Key</label>
+        <input value={supabaseKey} onChange={(e) => setSupabaseKey(e.target.value)} />
+      </div>
+      <button type="submit" className="save-btn">Salvar</button>
+    </form>
+  );
+}

--- a/dashboard/src/pages/Tenants.css
+++ b/dashboard/src/pages/Tenants.css
@@ -1,0 +1,6 @@
+.tenants { padding: 20px; }
+.page-header { display:flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
+.tenants-table { width:100%; border-collapse: collapse; }
+.tenants-table th, .tenants-table td { border:1px solid #ddd; padding:8px; }
+.edit-btn, .delete-btn, .new-btn { margin-right:8px; }
+.loading { text-align:center; padding:40px; }

--- a/dashboard/src/pages/Tenants.jsx
+++ b/dashboard/src/pages/Tenants.jsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { tenantService } from '../services/api';
+import './Tenants.css';
+
+export default function Tenants() {
+  const [tenants, setTenants] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    loadTenants();
+  }, []);
+
+  const loadTenants = async () => {
+    setLoading(true);
+    try {
+      const data = await tenantService.getTenants();
+      setTenants(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error('Erro ao carregar tenants', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const removeTenant = async (id) => {
+    if (!window.confirm('Deseja remover este tenant?')) return;
+    try {
+      await tenantService.deleteTenant(id);
+      setTenants(tenants.filter(t => t.id !== id));
+    } catch (err) {
+      console.error('Erro ao remover tenant', err);
+    }
+  };
+
+  if (loading) {
+    return <div className="tenants"><div className="loading">Carregando...</div></div>;
+  }
+
+  return (
+    <div className="tenants">
+      <div className="page-header">
+        <h1>Tenants</h1>
+        <button onClick={() => navigate('/tenants/new')} className="new-btn">Novo</button>
+      </div>
+      <table className="tenants-table">
+        <thead>
+          <tr>
+            <th>Nome</th>
+            <th>Credenciais</th>
+            <th>Ações</th>
+          </tr>
+        </thead>
+        <tbody>
+          {tenants.map((t) => (
+            <tr key={t.id}>
+              <td>{t.name || t.nome}</td>
+              <td>
+                <pre>{JSON.stringify(t.credentials || {}, null, 2)}</pre>
+              </td>
+              <td>
+                <Link to={`/tenants/${t.id}`} className="edit-btn">Editar</Link>
+                <button onClick={() => removeTenant(t.id)} className="delete-btn">Excluir</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/dashboard/src/services/api.js
+++ b/dashboard/src/services/api.js
@@ -254,4 +254,27 @@ export const dashboardService = {
   }
 };
 
+export const tenantService = {
+  getTenants: async () => {
+    const response = await api.get('/tenants');
+    return response.data;
+  },
+  getTenant: async (id) => {
+    const response = await api.get(`/tenants/${id}`);
+    return response.data;
+  },
+  createTenant: async (tenant) => {
+    const response = await api.post('/tenants', tenant);
+    return response.data;
+  },
+  updateTenant: async (id, tenant) => {
+    const response = await api.put(`/tenants/${id}`, tenant);
+    return response.data;
+  },
+  deleteTenant: async (id) => {
+    const response = await api.delete(`/tenants/${id}`);
+    return response.data;
+  }
+};
+
 export default api; 

--- a/index.js
+++ b/index.js
@@ -43,7 +43,9 @@ app.get('/', (req, res) => {
 // API da Dashboard (/api/painel)
 // ------------------------------
 const painelRouter = require('./routes/painel');
+const tenantRouter = require('./routes/tenant');
 app.use('/api/painel', painelRouter);
+app.use('/api/tenants', tenantRouter);
 
 // Rota de webhook para receber mensagens do Z-API
 app.post('/webhook', webhookLimiter, async (req, res) => {

--- a/routes/tenant.js
+++ b/routes/tenant.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const router = express.Router();
+const tenantService = require('../services/tenantService');
+
+// Middleware de API Key semelhante ao painel
+router.use((req, res, next) => {
+  const requiredKey = process.env.DASHBOARD_API_KEY;
+  if (!requiredKey) return next();
+  const key = req.header('x-api-key');
+  if (key !== requiredKey) return res.status(401).json({ error: 'unauthorized' });
+  next();
+});
+
+// Listar todos os tenants
+router.get('/', async (req, res) => {
+  try {
+    const tenants = await tenantService.listTenants();
+    res.json(tenants);
+  } catch (error) {
+    console.error('[tenants/list] erro:', error.message);
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+// Obter um tenant específico
+router.get('/:id', async (req, res) => {
+  try {
+    const tenant = await tenantService.getTenant(req.params.id);
+    if (!tenant) return res.status(404).json({ error: 'not_found' });
+    res.json(tenant);
+  } catch (error) {
+    console.error('[tenants/get] erro:', error.message);
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+// Criar novo tenant
+router.post('/', async (req, res) => {
+  try {
+    const created = await tenantService.createTenant(req.body);
+    res.status(201).json(created);
+  } catch (error) {
+    console.error('[tenants/create] erro:', error.message);
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+// Atualizar tenant existente
+router.put('/:id', async (req, res) => {
+  try {
+    const updated = await tenantService.updateTenant(req.params.id, req.body);
+    if (!updated) return res.status(404).json({ error: 'not_found' });
+    res.json(updated);
+  } catch (error) {
+    console.error('[tenants/update] erro:', error.message);
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+// Remover tenant
+router.delete('/:id', async (req, res) => {
+  try {
+    await tenantService.deleteTenant(req.params.id);
+    res.json({ success: true });
+  } catch (error) {
+    console.error('[tenants/delete] erro:', error.message);
+    res.status(500).json({ error: 'internal_error' });
+  }
+});
+
+module.exports = router;

--- a/services/tenantService.js
+++ b/services/tenantService.js
@@ -1,0 +1,57 @@
+const { supabase } = require('./supabaseClient');
+
+const TENANTS_TABLE = 'tenants';
+let memoryTenants = [];
+
+async function listTenants() {
+  if (!supabase) return memoryTenants;
+  const { data, error } = await supabase.from(TENANTS_TABLE).select('*').order('created_at', { ascending: true });
+  if (error) throw error;
+  return data || [];
+}
+
+async function getTenant(id) {
+  if (!supabase) return memoryTenants.find(t => t.id === id) || null;
+  const { data, error } = await supabase.from(TENANTS_TABLE).select('*').eq('id', id).single();
+  if (error) throw error;
+  return data;
+}
+
+async function createTenant(tenant) {
+  if (!supabase) {
+    const newTenant = { id: Date.now().toString(), ...tenant };
+    memoryTenants.push(newTenant);
+    return newTenant;
+  }
+  const { data, error } = await supabase.from(TENANTS_TABLE).insert(tenant).select().single();
+  if (error) throw error;
+  return data;
+}
+
+async function updateTenant(id, tenant) {
+  if (!supabase) {
+    memoryTenants = memoryTenants.map(t => (t.id === id ? { ...t, ...tenant } : t));
+    return memoryTenants.find(t => t.id === id) || null;
+  }
+  const { data, error } = await supabase.from(TENANTS_TABLE).update(tenant).eq('id', id).select().single();
+  if (error) throw error;
+  return data;
+}
+
+async function deleteTenant(id) {
+  if (!supabase) {
+    memoryTenants = memoryTenants.filter(t => t.id !== id);
+    return { success: true };
+  }
+  const { error } = await supabase.from(TENANTS_TABLE).delete().eq('id', id);
+  if (error) throw error;
+  return { success: true };
+}
+
+module.exports = {
+  listTenants,
+  getTenant,
+  createTenant,
+  updateTenant,
+  deleteTenant
+};


### PR DESCRIPTION
## Summary
- add tenant service and REST routes
- add dashboard pages for listing and editing tenants
- expose tenant APIs via dashboard service

## Testing
- `npm test` (fails: Error: no test specified)
- `(cd dashboard && npm test)` (fails: Missing script)
- `(cd dashboard && npm run lint)` (fails: lint errors)
- `(cd dashboard && npm run build)`

------
https://chatgpt.com/codex/tasks/task_b_68ab8cbb438c83209d20df066182c396